### PR TITLE
Fix typo and control .remarkrc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 # Don't change me! Compliance team is the owner of these files
 /.github/                   @saic-oss/compliance
 /.pre-commit-config.yaml    @saic-oss/compliance
-/Taskfile.yaml              @saic-oss/compliance
+/Taskfile.yml               @saic-oss/compliance
+/.remarkrc                  @saic-oss/compliance


### PR DESCRIPTION
## what
- Fix typo (.yaml -> .yml)
- Make @saic-oss/compliance the codeowner of .remarkrc

## why
- Control the right files

## references
N/A
