### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,4 @@
 /.pre-commit-config.yaml    @saic-oss/compliance
 /Taskfile.yml               @saic-oss/compliance
 /.remarkrc                  @saic-oss/compliance
+/LICENSE                    @saic-oss/compliance


### PR DESCRIPTION
## what/why
- Make @saic-oss/compliance the codeowner of LICENSE
    - Changes to the license of any project requires admin approval
