### PR TITLE
Disable Auto DevOps in GitLab project

### DIFF
--- a/examples/complete/1-infra/main.tf
+++ b/examples/complete/1-infra/main.tf
@@ -123,7 +123,7 @@ module "rancher-k8s-cluster" {
 }
 
 module "k8s-devsecops-sandbox" {
-  source                   = "git::https://github.com/saic-oss/terraform-k8s-devsecops-sandbox.git?ref=tags/0.4.6"
+  source                   = "git::https://github.com/saic-oss/terraform-k8s-devsecops-sandbox.git?ref=tags/0.4.8"
   cluster_issuer           = "letsencrypt-${var.letsencrypt_environment}"
   kubeconfig_file_contents = module.rancher-k8s-cluster.cluster_kubeconfig
   gitlab_host_name         = "gl.${random_pet.default.id}.${var.hosted_zone_domain_name}"

--- a/gitlab.tf
+++ b/gitlab.tf
@@ -44,7 +44,7 @@ resource "gitlab_project" "demo" {
   merge_requests_enabled                           = true
   only_allow_merge_if_pipeline_succeeds            = true
   only_allow_merge_if_all_discussions_are_resolved = true
-  pipelines_enabled                                = true
+  pipelines_enabled                                = false
   initialize_with_readme                           = false
   import_url                                       = "https://github.com/saic-oss/venus-demo.git"
   approvals_before_merge                           = 1


### PR DESCRIPTION
## what
* Disabled Auto DevOps in the imported project
* Updated tag for sandbox module

## why
* Auto DevOps is enabled instance-wide by default
* This should only deploy a GitLab CI pipeline if the expected files are found at root
* The Auto DevOps pipeline still tried to run even without the expected files, causing failures
* We are using Jenkins for a pipeline, so GitLab CI is not necessary
